### PR TITLE
zsh: improve $USER and $HOME robustness

### DIFF
--- a/zsh
+++ b/zsh
@@ -5,6 +5,16 @@ INSTALL="apt install -y"
 
 $UPDATE
 $INSTALL zsh git curl
+
+# set important environment variables if they haven't been set
+# POSIX: https://pubs.opengroup.org/onlinepubs/009695299/utilities/id.html
+USER=${USER:-$(id -u -n)}
+# POSIX: https://pubs.opengroup.org/onlinepubs/009696899/basedefs/xbd_chap08.html#tag_08_03
+HOME="${HOME:-$(getent passwd $USER 2>/dev/null | cut -d: -f6)}"
+# macOS does not have getent, but this works even if $HOME is unset
+HOME="${HOME:-$(eval echo ~$USER)}"
+
+# oh-my-zsh install
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended --keep-zshrc
 
 # nuke oh-my-zsh's zshrc, replace it with mine


### PR DESCRIPTION
$USER and $HOME might be unset / undefined at time of execution (cloud init)